### PR TITLE
Remove scala lib from classpath

### DIFF
--- a/org.knime.workbench.extension.scala/.classpath
+++ b/org.knime.workbench.extension.scala/.classpath
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.scala-ide.sdt.launching.SCALA_CONTAINER"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>


### PR DESCRIPTION
Scala lib is provided by the plugin dependency, so removing it from the
project classpath unsures that Eclipse uses the correct version.
